### PR TITLE
Enhanced booking in station-popup

### DIFF
--- a/src/components/map/bike-map.tsx
+++ b/src/components/map/bike-map.tsx
@@ -36,7 +36,7 @@ const BikeMap: React.FC<BikeMapProps> = ({ className, isLoggedIn }) => {
   const [selectedStation, setSelectedStation] = useState<number | null>(null);
   const [stations] = useStations();
   const [, loadStationDetail] = useOpenableStation();
-  const { cancelBooking } = useBooking();
+  const { booking, fetchBooking, cancelBooking } = useBooking();
 
   const handleHashChange = useCallback(() => {
     const stationId = window.location.hash.substr(1);
@@ -78,10 +78,18 @@ const BikeMap: React.FC<BikeMapProps> = ({ className, isLoggedIn }) => {
   );
   const handleCancelBooking = useCallback(
     () => {
+      fetchBooking();
+      const wasBookingForCurrentStation = booking && booking.stationId === selectedStation;
       cancelBooking()
-        .then(() => closePopup());
+        .then(() => {
+          closePopup();
+          if (!wasBookingForCurrentStation && selectedStation) {
+            loadStationDetail(selectedStation);
+            setSelectedStation(selectedStation);
+          }
+        });
     },
-    [],
+    [booking, selectedStation],
   );
   const handleRent = useCallback(
     (pin: string, slotId: number) => {

--- a/src/components/map/bike-map.tsx
+++ b/src/components/map/bike-map.tsx
@@ -8,7 +8,7 @@ import { toast } from 'react-toastify';
 import { useCachedViewport } from '../../hooks/map';
 import { useStations } from '../../hooks/stations';
 import { InvalidStatusCodeError } from '../../model';
-import { bookBike, rentBike, cancelCurrentBooking } from '../../model/stations';
+import { bookBike, cancelCurrentBooking, rentBike } from '../../model/stations';
 import { TILE_URL } from '../../model/urls';
 import { LanguageContext } from '../../resources/language';
 import logo from '../../resources/logo.png';

--- a/src/components/map/bike-map.tsx
+++ b/src/components/map/bike-map.tsx
@@ -80,7 +80,12 @@ const BikeMap: React.FC<BikeMapProps> = ({ className, isLoggedIn }) => {
     () => {
       fetchBooking().then(() => {
         if (!booking) {
-          throw new Error("Trying to cancel a booking, but no bike booked.");
+          closePopup();
+          if (selectedStation) {
+            loadStationDetail(selectedStation);
+            setSelectedStation(selectedStation);
+          }
+          return;
         }
 
         const wasBookingForCurrentStation = booking.stationId === selectedStation;

--- a/src/components/map/bike-map.tsx
+++ b/src/components/map/bike-map.tsx
@@ -5,9 +5,9 @@ import { Map, Marker, TileLayer } from 'react-leaflet';
 import { toast } from 'react-toastify';
 
 import { useCachedViewport, useOpenableStation } from '../../hooks/map';
-import { useStations } from '../../hooks/stations';
+import { useStations, useBooking } from '../../hooks/stations';
 import { InvalidStatusCodeError } from '../../model';
-import { bookBike, cancelCurrentBooking, rentBike } from '../../model/stations';
+import { bookBike, rentBike } from '../../model/stations';
 import { TILE_URL } from '../../model/urls';
 import { LanguageContext } from '../../resources/language';
 import logo from '../../resources/logo.png';
@@ -36,6 +36,7 @@ const BikeMap: React.FC<BikeMapProps> = ({ className, isLoggedIn }) => {
   const [selectedStation, setSelectedStation] = useState<number | null>(null);
   const [stations] = useStations();
   const [, loadStationDetail] = useOpenableStation();
+  const { cancelBooking } = useBooking();
 
   const handleHashChange = useCallback(() => {
     const stationId = window.location.hash.substr(1);
@@ -77,7 +78,7 @@ const BikeMap: React.FC<BikeMapProps> = ({ className, isLoggedIn }) => {
   );
   const handleCancelBooking = useCallback(
     () => {
-      cancelCurrentBooking()
+      cancelBooking()
         .then(() => closePopup());
     },
     [],

--- a/src/components/map/bike-map.tsx
+++ b/src/components/map/bike-map.tsx
@@ -1,11 +1,10 @@
-import { navigate } from '@reach/router';
 import { icon } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { Map, Marker, TileLayer } from 'react-leaflet';
 import { toast } from 'react-toastify';
 
-import { useCachedViewport } from '../../hooks/map';
+import { useCachedViewport, useOpenableStation } from '../../hooks/map';
 import { useStations } from '../../hooks/stations';
 import { InvalidStatusCodeError } from '../../model';
 import { bookBike, cancelCurrentBooking, rentBike } from '../../model/stations';
@@ -36,6 +35,7 @@ const BikeMap: React.FC<BikeMapProps> = ({ className, isLoggedIn }) => {
   const [viewport, handleViewportChange] = useCachedViewport();
   const [selectedStation, setSelectedStation] = useState<number | null>(null);
   const [stations] = useStations();
+  const [, loadStationDetail] = useOpenableStation();
 
   const handleHashChange = useCallback(() => {
     const stationId = window.location.hash.substr(1);
@@ -63,7 +63,11 @@ const BikeMap: React.FC<BikeMapProps> = ({ className, isLoggedIn }) => {
       }
 
       bookBike(selectedStation)
-        .then(() => navigate('/bookings'))
+        .then(() => {
+          closePopup();
+          loadStationDetail(selectedStation);
+          setSelectedStation(selectedStation);
+        })
         .catch(err => {
           console.error("Error while reserving bike:", err);
           toast(MAP.POPUP.RENT_DIALOG.ALERT.DEFAULT_ERR, { type: 'error' });

--- a/src/components/map/bike-map.tsx
+++ b/src/components/map/bike-map.tsx
@@ -8,7 +8,7 @@ import { toast } from 'react-toastify';
 import { useCachedViewport } from '../../hooks/map';
 import { useStations } from '../../hooks/stations';
 import { InvalidStatusCodeError } from '../../model';
-import { bookBike, rentBike } from '../../model/stations';
+import { bookBike, rentBike, cancelCurrentBooking } from '../../model/stations';
 import { TILE_URL } from '../../model/urls';
 import { LanguageContext } from '../../resources/language';
 import logo from '../../resources/logo.png';
@@ -70,6 +70,13 @@ const BikeMap: React.FC<BikeMapProps> = ({ className, isLoggedIn }) => {
         });
     },
     [selectedStation, MAP],
+  );
+  const handleCancelBooking = useCallback(
+    () => {
+      cancelCurrentBooking()
+        .then(() => closePopup());
+    },
+    [],
   );
   const handleRent = useCallback(
     (pin: string, slotId: number) => {
@@ -143,6 +150,7 @@ const BikeMap: React.FC<BikeMapProps> = ({ className, isLoggedIn }) => {
           openedStationId={selectedStation}
           stations={stations}
           onBookBike={handleBook}
+          onCancelBooking={handleCancelBooking}
           onRentBike={handleRent}
         />
       </Overlay>

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -160,6 +160,19 @@ const RentPopup: React.FC<RentPopupProps> = ({
     [openedStationId],
   );
 
+  useEffect(
+    () => {
+      if (booking && openedStationId && stationDetail && openedStationId === booking.stationId) {
+        const bookedSlot =
+          stationDetail.slots.stationSlots.find(slot => slot.stationSlotPosition === booking.stationSlotPosition);
+        if (bookedSlot) {
+            setSelectedSlot(bookedSlot);
+        }
+      }
+    },
+    [booking, openedStationId, stationDetail, setSelectedSlot],
+  );
+
   const selectedStation = useMemo(
     () => stations.find(stat => stat.stationId === openedStationId),
     [openedStationId],
@@ -244,8 +257,6 @@ const RentPopup: React.FC<RentPopupProps> = ({
 
                     const handleClick = () =>
                       (!isReserved || isReservedByMe) && setSelectedSlot(slot);
-
-                    if (isReservedByMe && !selectedSlot) { setSelectedSlot(slot); }
 
                     return (
                       <li

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -12,7 +12,7 @@ import Measure, { ContentRect } from 'react-measure';
 import { useFormField } from '../../hooks/form';
 import { useOpenableStation, OpenedStation } from '../../hooks/map';
 import { useSavedPin } from '../../hooks/pin';
-import { useBooking, useStations } from '../../hooks/stations';
+import { useBooking } from '../../hooks/stations';
 import { Booking, Slot, Station } from '../../model';
 import { LanguageContext } from '../../resources/language';
 import Spinner from '../util/spinner';
@@ -24,6 +24,7 @@ interface RentControlsProps {
   booking: Booking | null;
   openedStation: OpenedStation;
   selectedSlot: Slot | null;
+  stations: Station[];
 
   onBookBike: React.MouseEventHandler;
   onCancelBooking: React.MouseEventHandler;
@@ -34,6 +35,7 @@ const RentControls: React.FC<RentControlsProps> = ({
   booking,
   openedStation,
   selectedSlot,
+  stations,
 
   onBookBike,
   onCancelBooking,
@@ -51,13 +53,12 @@ const RentControls: React.FC<RentControlsProps> = ({
   );
 
   const { map, BUCHUNGEN } = useContext(LanguageContext);
-  const [stations] = useStations();
 
   const canRentBike =
     openedStation.station.state === 'OPERATIVE' &&
     openedStation.slots.stationSlots.some(s => s.isOccupied);
   const bookedStation = booking && stations.find(station => station.stationId === booking.stationId);
-  const isCurrentStationBooked = bookedStation && (bookedStation.stationId === openedStation.station.stationId);
+  const isOpenedStationBooked = booking && (booking.stationId === openedStation.station.stationId);
 
   return (
     pin ? (
@@ -84,7 +85,7 @@ const RentControls: React.FC<RentControlsProps> = ({
           {!booking ?
             map.BOOKING.BOOK_BIKE :
               BUCHUNGEN.RESERVIERUNG.BUTTON +
-              (!isCurrentStationBooked ? ` (${bookedStation && bookedStation.name})` : '')
+              (!isOpenedStationBooked ? ` (${bookedStation!.name})` : '')
           }
         </button>
       </div>
@@ -282,6 +283,7 @@ const RentPopup: React.FC<RentPopupProps> = ({
                     booking={booking}
                     openedStation={stationDetail}
                     selectedSlot={selectedSlot}
+                    stations={stations}
                     onBookBike={onBookBike}
                     onCancelBooking={onCancelBooking}
                     onRentBike={handleRent}

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -12,7 +12,7 @@ import Measure, { ContentRect } from 'react-measure';
 import { useFormField } from '../../hooks/form';
 import { useOpenableStation, OpenedStation } from '../../hooks/map';
 import { useSavedPin } from '../../hooks/pin';
-import { useBooking } from '../../hooks/stations';
+import { useBooking, useStations } from '../../hooks/stations';
 import { Booking, Slot, Station } from '../../model';
 import { LanguageContext } from '../../resources/language';
 import Spinner from '../util/spinner';
@@ -51,10 +51,13 @@ const RentControls: React.FC<RentControlsProps> = ({
   );
 
   const { map, BUCHUNGEN } = useContext(LanguageContext);
+  const [stations] = useStations();
 
   const canRentBike =
     openedStation.station.state === 'OPERATIVE' &&
     openedStation.slots.stationSlots.some(s => s.isOccupied);
+  const bookedStation = booking && stations.find(station => station.stationId === booking.stationId);
+  const isCurrentStationBooked = bookedStation && (bookedStation.stationId === openedStation.station.stationId);
 
   return (
     pin ? (
@@ -80,7 +83,8 @@ const RentControls: React.FC<RentControlsProps> = ({
         >
           {!booking ?
             map.BOOKING.BOOK_BIKE :
-            BUCHUNGEN.RESERVIERUNG.BUTTON
+              BUCHUNGEN.RESERVIERUNG.BUTTON +
+              (!isCurrentStationBooked ? ` (${bookedStation && bookedStation.name})` : '')
           }
         </button>
       </div>

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -245,6 +245,8 @@ const RentPopup: React.FC<RentPopupProps> = ({
                     const handleClick = () =>
                       (!isReserved || isReservedByMe) && setSelectedSlot(slot);
 
+                    if (isReservedByMe && !selectedSlot) { setSelectedSlot(slot); }
+
                     return (
                       <li
                         className="slot-entry column"

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -26,6 +26,7 @@ interface RentControlsProps {
   selectedSlot: Slot | null;
 
   onBookBike: React.MouseEventHandler;
+  onCancelBooking: React.MouseEventHandler;
   onRentBike: (pin: string) => void;
 }
 
@@ -35,6 +36,7 @@ const RentControls: React.FC<RentControlsProps> = ({
   selectedSlot,
 
   onBookBike,
+  onCancelBooking,
   onRentBike,
 }) => {
   const [pin, setPin] = useSavedPin();
@@ -48,12 +50,11 @@ const RentControls: React.FC<RentControlsProps> = ({
     [pinInput],
   );
 
-  const { map, MAP } = useContext(LanguageContext);
+  const { map, MAP, BUCHUNGEN } = useContext(LanguageContext);
 
   const canRentBike =
     openedStation.station.state === 'OPERATIVE' &&
     openedStation.slots.stationSlots.some(s => s.isOccupied);
-  const canBookBike = canRentBike && !booking;
 
   return (
     pin ? (
@@ -74,10 +75,13 @@ const RentControls: React.FC<RentControlsProps> = ({
 
         <button
           className="btn outline book"
-          disabled={!canBookBike}
-          onClick={onBookBike}
+          disabled={!canRentBike && !booking}
+          onClick={!booking ? onBookBike : onCancelBooking}
         >
-          {MAP.POPUP.BUTTON.BOOK}
+          {!booking ?
+            MAP.POPUP.BUTTON.BOOK :
+            BUCHUNGEN.RESERVIERUNG.BUTTON
+          }
         </button>
       </div>
     ) : (
@@ -115,6 +119,7 @@ interface RentPopupProps {
   stations: Station[];
 
   onBookBike: () => void;
+  onCancelBooking: () => void;
   onRentBike: (pin: string, slotId: number) => void;
 }
 
@@ -125,6 +130,7 @@ const RentPopup: React.FC<RentPopupProps> = ({
   stations,
 
   onBookBike,
+  onCancelBooking,
   onRentBike,
 }) => {
   const { booking, fetchBooking } = useBooking();
@@ -271,6 +277,7 @@ const RentPopup: React.FC<RentPopupProps> = ({
                     openedStation={stationDetail}
                     selectedSlot={selectedSlot}
                     onBookBike={onBookBike}
+                    onCancelBooking={onCancelBooking}
                     onRentBike={handleRent}
                   />
                 ) : (

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -84,8 +84,7 @@ const RentControls: React.FC<RentControlsProps> = ({
         >
           {!booking ?
             map.BOOKING.BOOK_BIKE :
-              BUCHUNGEN.RESERVIERUNG.BUTTON +
-              (!isOpenedStationBooked ? ` (${bookedStation!.name})` : '')
+            `${BUCHUNGEN.RESERVIERUNG.BUTTON} ${!isOpenedStationBooked ? `(${bookedStation!.name})` : ''}`
           }
         </button>
       </div>

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -162,12 +162,13 @@ const RentPopup: React.FC<RentPopupProps> = ({
 
   useEffect(
     () => {
-      if (booking && openedStationId && stationDetail && openedStationId === booking.stationId) {
-        const bookedSlot =
-          stationDetail.slots.stationSlots.find(slot => slot.stationSlotPosition === booking.stationSlotPosition);
-        if (bookedSlot) {
-            setSelectedSlot(bookedSlot);
-        }
+      if (!booking || !openedStationId || !stationDetail || openedStationId !== booking.stationId) {
+        return;
+      }
+      const bookedSlot =
+        stationDetail.slots.stationSlots.find(slot => slot.stationSlotPosition === booking.stationSlotPosition);
+      if (bookedSlot) {
+          setSelectedSlot(bookedSlot);
       }
     },
     [booking, openedStationId, stationDetail, setSelectedSlot],

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -167,9 +167,7 @@ const RentPopup: React.FC<RentPopupProps> = ({
       }
       const bookedSlot =
         stationDetail.slots.stationSlots.find(slot => slot.stationSlotPosition === booking.stationSlotPosition);
-      if (bookedSlot) {
-          setSelectedSlot(bookedSlot);
-      }
+      bookedSlot && setSelectedSlot(bookedSlot);
     },
     [booking, openedStationId, stationDetail, setSelectedSlot],
   );

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -50,7 +50,7 @@ const RentControls: React.FC<RentControlsProps> = ({
     [pinInput],
   );
 
-  const { map, MAP, BUCHUNGEN } = useContext(LanguageContext);
+  const { map, BUCHUNGEN } = useContext(LanguageContext);
 
   const canRentBike =
     openedStation.station.state === 'OPERATIVE' &&
@@ -79,7 +79,7 @@ const RentControls: React.FC<RentControlsProps> = ({
           onClick={!booking ? onBookBike : onCancelBooking}
         >
           {!booking ?
-            MAP.POPUP.BUTTON.BOOK :
+            map.BOOKING.BOOK_BIKE :
             BUCHUNGEN.RESERVIERUNG.BUTTON
           }
         </button>

--- a/src/resources/language/de-extensions.json
+++ b/src/resources/language/de-extensions.json
@@ -25,6 +25,9 @@
       "CTA": "Geben Sie Ihre PIN ein, um ein Fahrrad auszuleihen. Ihre PIN wird gespeichert.",
       "ACTION": "Speichern"
     },
+    "BOOKING": {
+      "BOOK_BIKE": "Reservieren des vollgeladensten Fahrrades"
+    },
     "RENT": {
       "SLIDE_FOR_BIKE_NO1": "Fahrrad am Slot",
       "SLIDE_FOR_BIKE_NO2": "ausleihen",

--- a/src/resources/language/en-extensions.json
+++ b/src/resources/language/en-extensions.json
@@ -25,6 +25,9 @@
       "CTA": "Enter your PIN to rent a bike. You will only have to do this once.",
       "ACTION": "Save"
     },
+    "BOOKING": {
+      "BOOK_BIKE": "Book the most-charged bike"
+    },
     "RENT": {
       "SLIDE_FOR_BIKE_NO1": "Slide to rent bike at slot",
       "SLIDE_FOR_BIKE_NO2": "",


### PR DESCRIPTION
_The current flow when booking a bike takes the user away from the map and to the bookings tab. While a direct link back to the booked station exists, staying on the selected station popup greatly enhances the user experience in my opinion._
 
This pull request contains the following changes:
- a current booking can be canceled from the same button it was initiated from
- the booking button now explicitly says that the most-charged bike will be reserved
  (one could have thought that a specific slot can be booked after selecting it)
- after booking, the popup automatically refreshes while staying open to reflect the changed state
  (in the past, this wasn't necessary due to directing the user to the bookings tab)
- when selecting another station while still having a booking for a different one, the button additionally tells the user which station the cancellation affects
  (and thereby there should be no confusion about which station the booking belongs to)
- the station-popup automatically selects the slot which has been booked (as if the user clicked it)
  (the renting slider becomes more specific than "most-charged bike")
  (naturally, another slot can still be selected and rented instead)