### PR TITLE
Add „Refresh booking“ button 

### DIFF
--- a/src/components/map/rent-controls.tsx
+++ b/src/components/map/rent-controls.tsx
@@ -91,7 +91,7 @@ const RentControls: React.FC<RentControlsProps> = ({
           className="btn outline book"
           onClick={onRefreshBooking}
         >
-          Refresh booking
+          {map.BOOKING.REFRESH}
         </button>
       }
     </div>

--- a/src/components/map/rent-controls.tsx
+++ b/src/components/map/rent-controls.tsx
@@ -86,14 +86,15 @@ const RentControls: React.FC<RentControlsProps> = ({
               !isOpenedStationBooked ? `(${bookedStation!.name})` : ''
             }`}
       </button>
-      {isOpenedStationBooked &&
+      {booking && (
         <button
           className="btn outline book"
+          disabled={!booking}
           onClick={onRefreshBooking}
         >
-          {map.BOOKING.REFRESH}
+          {isOpenedStationBooked ? map.BOOKING.REFRESH : map.BOOKING.SWITCH}
         </button>
-      }
+      )}
     </div>
   ) : (
     <form

--- a/src/components/map/rent-controls.tsx
+++ b/src/components/map/rent-controls.tsx
@@ -56,12 +56,12 @@ const RentControls: React.FC<RentControlsProps> = ({
     stations.find(station => station.stationId === booking.stationId);
   const isOpenedStationBooked =
     booking && booking.stationId === openedStation.station.stationId;
-  const remainingBookingMinutes =
-    booking
-    ? new Date(
-      Date.parse(booking.expiryDateTime) - Date.now(),
-      ).getUTCMinutes()
+  const remainingBookingTime = booking
+    ? Date.parse(booking.expiryDateTime) - Date.now()
     : 0;
+  const remainingBookingMinutes = new Date(
+    remainingBookingTime,
+  ).getUTCMinutes();
 
   return pin ? (
     <div className={classNames('rent-controls', className)}>

--- a/src/components/map/rent-controls.tsx
+++ b/src/components/map/rent-controls.tsx
@@ -56,6 +56,12 @@ const RentControls: React.FC<RentControlsProps> = ({
     stations.find(station => station.stationId === booking.stationId);
   const isOpenedStationBooked =
     booking && booking.stationId === openedStation.station.stationId;
+  const remainingBookingMinutes =
+    booking
+    ? new Date(
+      Date.parse(booking.expiryDateTime) - Date.now(),
+      ).getUTCMinutes()
+    : 0;
 
   return pin ? (
     <div className={classNames('rent-controls', className)}>
@@ -86,17 +92,17 @@ const RentControls: React.FC<RentControlsProps> = ({
               !isOpenedStationBooked ? `(${bookedStation!.name})` : ''
             }`}
       </button>
-      <button
-        className="btn outline book"
-        disabled={!booking}
-        onClick={onRefreshBooking}
-      >
-        {booking && isOpenedStationBooked
-          ? `${map.BOOKING.REFRESH} (${new Date(
-              Date.parse(booking.expiryDateTime) - Date.now(),
-            ).getUTCMinutes()} ${map.BOOKING.MINUTES_REMAINING})`
-          : map.BOOKING.SWITCH}
-      </button>
+      {booking &&
+        <button
+          className="btn outline book"
+          disabled={!isOpenedStationBooked || remainingBookingMinutes >= 14}
+          onClick={onRefreshBooking}
+        >
+          {booking && isOpenedStationBooked
+            ? `${map.BOOKING.REFRESH} (${remainingBookingMinutes} ${map.BOOKING.MINUTES_REMAINING})`
+            : map.BOOKING.SWITCH}
+        </button>
+      }
     </div>
   ) : (
     <form

--- a/src/components/map/rent-controls.tsx
+++ b/src/components/map/rent-controls.tsx
@@ -89,10 +89,14 @@ const RentControls: React.FC<RentControlsProps> = ({
       {booking && (
         <button
           className="btn outline book"
-          disabled={!booking}
           onClick={onRefreshBooking}
         >
-          {isOpenedStationBooked ? map.BOOKING.REFRESH : map.BOOKING.SWITCH}
+          {isOpenedStationBooked
+            ? `${map.BOOKING.REFRESH} (${
+              (new Date(Date.parse(booking.expiryDateTime) - Date.now())).getUTCMinutes()
+            } ${map.BOOKING.MINUTES_REMAINING})`
+            : map.BOOKING.SWITCH
+          }
         </button>
       )}
     </div>

--- a/src/components/map/rent-controls.tsx
+++ b/src/components/map/rent-controls.tsx
@@ -19,6 +19,7 @@ interface RentControlsProps {
 
   onBookBike: React.MouseEventHandler;
   onCancelBooking: React.MouseEventHandler;
+  onRefreshBooking: React.MouseEventHandler;
   onRentBike: (pin: string) => void;
 }
 
@@ -31,6 +32,7 @@ const RentControls: React.FC<RentControlsProps> = ({
 
   onBookBike,
   onCancelBooking,
+  onRefreshBooking,
   onRentBike,
 }) => {
   const [pin, setPin] = useSavedPin();
@@ -84,6 +86,14 @@ const RentControls: React.FC<RentControlsProps> = ({
               !isOpenedStationBooked ? `(${bookedStation!.name})` : ''
             }`}
       </button>
+      {isOpenedStationBooked &&
+        <button
+          className="btn outline book"
+          onClick={onRefreshBooking}
+        >
+          Refresh booking
+        </button>
+      }
     </div>
   ) : (
     <form

--- a/src/components/map/rent-controls.tsx
+++ b/src/components/map/rent-controls.tsx
@@ -86,19 +86,17 @@ const RentControls: React.FC<RentControlsProps> = ({
               !isOpenedStationBooked ? `(${bookedStation!.name})` : ''
             }`}
       </button>
-      {booking && (
-        <button
-          className="btn outline book"
-          onClick={onRefreshBooking}
-        >
-          {isOpenedStationBooked
-            ? `${map.BOOKING.REFRESH} (${
-              (new Date(Date.parse(booking.expiryDateTime) - Date.now())).getUTCMinutes()
-            } ${map.BOOKING.MINUTES_REMAINING})`
-            : map.BOOKING.SWITCH
-          }
-        </button>
-      )}
+      <button
+        className="btn outline book"
+        disabled={!booking}
+        onClick={onRefreshBooking}
+      >
+        {(booking && isOpenedStationBooked)
+          ? `${map.BOOKING.REFRESH} (${new Date(
+              Date.parse(booking.expiryDateTime) - Date.now(),
+            ).getUTCMinutes()} ${map.BOOKING.MINUTES_REMAINING})`
+          : map.BOOKING.SWITCH}
+      </button>
     </div>
   ) : (
     <form

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -32,7 +32,7 @@ const RentPopup: React.FC<RentPopupProps> = ({
 
   onRequestClose,
 }) => {
-  const { booking, cancelBooking, fetchBooking } = useBooking();
+  const { booking, cancelBooking, fetchBooking, refreshBooking } = useBooking();
   const {
     availableSlots,
     stationDetail,
@@ -87,22 +87,14 @@ const RentPopup: React.FC<RentPopupProps> = ({
       });
   }, [booking, fetchBooking, fetchStationDetail, selectedStation, BUCHUNGEN]);
 
-  const handleRefreshBooking = useCallback(() => {
-    if (!booking) {
-      throw new Error('Trying to refresh a booking, but no bike booked.');
-    }
-    if (!selectedStation) {
-      throw new Error('Trying to refresh a booking, but no station selected.');
-    }
-
-    return cancelBooking()
-      .then(() => bookBike(selectedStation.stationId))
+  const handleRefreshBooking = useCallback(() =>
+    refreshBooking()
       .then(() => Promise.all([fetchBooking(), fetchStationDetail()]))
       .catch(err => {
         console.error('Error while refreshing a booking:', err);
         toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });
-      });
-  }, [booking, fetchBooking, fetchStationDetail, selectedStation]);
+      }),
+    [fetchBooking, fetchStationDetail, refreshBooking, BUCHUNGEN]);
 
   const handleRent = useCallback(
     (pin: string) => {

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -102,7 +102,7 @@ const RentPopup: React.FC<RentPopupProps> = ({
         console.error('Error while refreshing a booking:', err);
         toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });
       });
-  }, [booking, fetchBooking, selectedStation]);
+  }, [booking, fetchBooking, fetchStationDetail, selectedStation]);
 
   const handleRent = useCallback(
     (pin: string) => {

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -91,12 +91,14 @@ const RentPopup: React.FC<RentPopupProps> = ({
     if (!booking) {
       throw new Error('Trying to refresh a booking, but no bike booked.');
     }
-    const canceledBooking = booking;
+    if (!selectedStation) {
+      throw new Error('Trying to refresh a booking, but no station selected.');
+    }
 
     return cancelBooking()
-      .then(() => bookBike(canceledBooking.stationId))
+      .then(() => bookBike(selectedStation.stationId))
       .then(() => Promise.all([fetchBooking(), fetchStationDetail()]));
-  }, [booking, fetchBooking]);
+  }, [booking, fetchBooking, selectedStation]);
 
   const handleRent = useCallback(
     (pin: string) => {

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -97,7 +97,11 @@ const RentPopup: React.FC<RentPopupProps> = ({
 
     return cancelBooking()
       .then(() => bookBike(selectedStation.stationId))
-      .then(() => Promise.all([fetchBooking(), fetchStationDetail()]));
+      .then(() => Promise.all([fetchBooking(), fetchStationDetail()]))
+      .catch(err => {
+        console.error('Error while refreshing a booking:', err);
+        toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });
+      });
   }, [booking, fetchBooking, selectedStation]);
 
   const handleRent = useCallback(

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -87,6 +87,17 @@ const RentPopup: React.FC<RentPopupProps> = ({
       });
   }, [booking, fetchBooking, fetchStationDetail, selectedStation, BUCHUNGEN]);
 
+  const handleRefreshBooking = useCallback(() => {
+    if (!booking) {
+      throw new Error('Trying to refresh a booking, but no bike booked.');
+    }
+    const canceledBooking = booking;
+
+    return cancelBooking()
+      .then(() => bookBike(canceledBooking.stationId))
+      .then(() => Promise.all([fetchBooking(), fetchStationDetail()]));
+  }, [booking, fetchBooking]);
+
   const handleRent = useCallback(
     (pin: string) => {
       if (!selectedStation || !stationDetail) {
@@ -164,6 +175,7 @@ const RentPopup: React.FC<RentPopupProps> = ({
                   stations={stations}
                   onBookBike={handleBook}
                   onCancelBooking={handleCancelBooking}
+                  onRefreshBooking={handleRefreshBooking}
                   onRentBike={handleRent}
                 />
               ) : (

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -93,15 +93,14 @@ const RentPopup: React.FC<RentPopupProps> = ({
       });
   }, [booking, cancelBooking, fetchStationDetail, BUCHUNGEN]);
 
-  const handleRefreshBooking = useCallback(
-    () =>
+  const handleRefreshBooking = useCallback(() =>
       refreshBooking()
-        .then(() => Promise.all([fetchBooking(), fetchStationDetail()]))
+        .then(fetchStationDetail)
         .catch(err => {
           console.error('Error while refreshing a booking:', err);
           toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });
         }),
-    [fetchBooking, fetchStationDetail, refreshBooking, BUCHUNGEN],
+    [fetchStationDetail, refreshBooking, BUCHUNGEN],
   );
 
   const handleRent = useCallback(

--- a/src/hooks/stations.ts
+++ b/src/hooks/stations.ts
@@ -52,16 +52,17 @@ export const useBooking = () => {
     () =>
       getCurrentBooking()
         .then(setBooking)
+        .then(() => cancelCurrentBooking())
         .then(() => {
-          const oldBooking = booking;
-          return cancelCurrentBooking()
-            .then(oldBooking && (() => bookBike(oldBooking.stationId)))
-            .catch(err => {
-              console.error('Failed refreshing current booking:', err);
-              toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });
-            });
+          if (booking) {
+            doBook(booking.stationId);
+          }
+        })
+        .catch(err => {
+          console.error('Failed refreshing current booking:', err);
+          toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });
         }),
-    [BUCHUNGEN],
+    [booking, BUCHUNGEN],
   );
 
   useInterval(fetchBooking);

--- a/src/hooks/stations.ts
+++ b/src/hooks/stations.ts
@@ -58,6 +58,8 @@ export const useBooking = () => {
             doBook(booking.stationId);
           }
         })
+        .then(() => getCurrentBooking())
+        .then(setBooking)
         .catch(err => {
           console.error('Failed refreshing current booking:', err);
           toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });

--- a/src/hooks/stations.ts
+++ b/src/hooks/stations.ts
@@ -52,7 +52,7 @@ export const useBooking = () => {
     async () => {
       try {
         const oldBooking = await getCurrentBooking();
-        await cancelBooking();
+        await cancelCurrentBooking();
         if (oldBooking) {
           const currBooking = await doBook(oldBooking.stationId);
           await setBooking(currBooking);

--- a/src/hooks/stations.ts
+++ b/src/hooks/stations.ts
@@ -50,18 +50,17 @@ export const useBooking = () => {
   );
   const refreshBooking = useCallback(
     async () => {
-      const oldBooking = await getCurrentBooking();
-      return cancelBooking()
-        .then(() => {
-          if (oldBooking) {
-            doBook(oldBooking.stationId);
-          }
-        })
-        .then(fetchBooking)
-        .catch(err => {
-          console.error('Failed refreshing current booking:', err);
-          toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });
-        });
+      try {
+        const oldBooking = await getCurrentBooking();
+        await cancelBooking();
+        if (oldBooking) {
+          await doBook(oldBooking.stationId);
+        }
+        await fetchBooking();
+      } catch (err) {
+        console.error('Failed refreshing current booking:', err);
+        toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });
+      }
     },
     [BUCHUNGEN],
   );

--- a/src/hooks/stations.ts
+++ b/src/hooks/stations.ts
@@ -51,7 +51,10 @@ export const useBooking = () => {
   const refreshBooking = useCallback(
     async () => {
       try {
-        const oldBooking = await getCurrentBooking();
+        let oldBooking = await getCurrentBooking();
+        if (!oldBooking) {
+          oldBooking = booking;
+        }
         await cancelCurrentBooking();
         if (oldBooking) {
           const currBooking = await doBook(oldBooking.stationId);

--- a/src/hooks/stations.ts
+++ b/src/hooks/stations.ts
@@ -49,22 +49,21 @@ export const useBooking = () => {
     [BUCHUNGEN],
   );
   const refreshBooking = useCallback(
-    () =>
-      getCurrentBooking()
-        .then(setBooking)
-        .then(() => cancelCurrentBooking())
+    async () => {
+      const oldBooking = await getCurrentBooking();
+      return cancelBooking()
         .then(() => {
-          if (booking) {
-            doBook(booking.stationId);
+          if (oldBooking) {
+            doBook(oldBooking.stationId);
           }
         })
-        .then(() => getCurrentBooking())
-        .then(setBooking)
+        .then(fetchBooking)
         .catch(err => {
           console.error('Failed refreshing current booking:', err);
           toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });
-        }),
-    [booking, BUCHUNGEN],
+        });
+    },
+    [BUCHUNGEN],
   );
 
   useInterval(fetchBooking);

--- a/src/hooks/stations.ts
+++ b/src/hooks/stations.ts
@@ -54,9 +54,11 @@ export const useBooking = () => {
         const oldBooking = await getCurrentBooking();
         await cancelBooking();
         if (oldBooking) {
-          await doBook(oldBooking.stationId);
+          const currBooking = await doBook(oldBooking.stationId);
+          await setBooking(currBooking);
+        } else {
+          await fetchBooking();
         }
-        await fetchBooking();
       } catch (err) {
         console.error('Failed refreshing current booking:', err);
         toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });

--- a/src/hooks/stations.ts
+++ b/src/hooks/stations.ts
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify';
 
 import { Booking, Station } from '../model';
 import {
+  bookBike,
   cancelCurrentBooking,
   getAllStations,
   getCurrentBooking,
@@ -37,10 +38,25 @@ export const useBooking = () => {
         }),
     [BUCHUNGEN],
   );
+  const refreshBooking = useCallback(
+    () =>
+      getCurrentBooking()
+        .then(setBooking)
+        .then(() => {
+          const oldBooking = booking;
+          return cancelCurrentBooking()
+            .then(oldBooking && (() => bookBike(oldBooking.stationId)))
+            .catch(err => {
+              console.error('Failed refreshing current booking:', err);
+              toast(BUCHUNGEN.ALERT.LOAD_CURR_BOOKING_ERR, { type: 'error' });
+            });
+        }),
+    [BUCHUNGEN],
+  );
 
   useInterval(fetchBooking);
 
-  return { booking, cancelBooking, fetchBooking };
+  return { booking, cancelBooking, fetchBooking, refreshBooking };
 };
 
 export const useStations = () => {

--- a/src/resources/language/de-extensions.json
+++ b/src/resources/language/de-extensions.json
@@ -27,6 +27,7 @@
     },
     "BOOKING": {
       "BOOK_BIKE": "Reservieren des vollgeladensten Fahrrades",
+      "MINUTES_REMAINING": "Minuten verbleibend",
       "REFRESH": "Buchung erneuern",
       "SWITCH": "Zu aktueller Station umbuchen"
     },

--- a/src/resources/language/de-extensions.json
+++ b/src/resources/language/de-extensions.json
@@ -27,7 +27,8 @@
     },
     "BOOKING": {
       "BOOK_BIKE": "Reservieren des vollgeladensten Fahrrades",
-      "REFRESH": "Buchung erneuern"
+      "REFRESH": "Buchung erneuern",
+      "SWITCH": "Zu aktueller Station umbuchen"
     },
     "RENT": {
       "SLIDE_FOR_BIKE_NO1": "Fahrrad am Slot",

--- a/src/resources/language/de-extensions.json
+++ b/src/resources/language/de-extensions.json
@@ -26,7 +26,8 @@
       "ACTION": "Speichern"
     },
     "BOOKING": {
-      "BOOK_BIKE": "Reservieren des vollgeladensten Fahrrades"
+      "BOOK_BIKE": "Reservieren des vollgeladensten Fahrrades",
+      "REFRESH": "Buchung erneuern"
     },
     "RENT": {
       "SLIDE_FOR_BIKE_NO1": "Fahrrad am Slot",

--- a/src/resources/language/en-extensions.json
+++ b/src/resources/language/en-extensions.json
@@ -27,7 +27,8 @@
     },
     "BOOKING": {
       "BOOK_BIKE": "Book the most-charged bike",
-      "REFRESH": "Refresh booking"
+      "REFRESH": "Refresh booking",
+      "SWITCH": "Switch current booking to this station"
     },
     "RENT": {
       "SLIDE_FOR_BIKE_NO1": "Slide to rent bike at slot",

--- a/src/resources/language/en-extensions.json
+++ b/src/resources/language/en-extensions.json
@@ -26,7 +26,8 @@
       "ACTION": "Save"
     },
     "BOOKING": {
-      "BOOK_BIKE": "Book the most-charged bike"
+      "BOOK_BIKE": "Book the most-charged bike",
+      "REFRESH": "Refresh booking"
     },
     "RENT": {
       "SLIDE_FOR_BIKE_NO1": "Slide to rent bike at slot",

--- a/src/resources/language/en-extensions.json
+++ b/src/resources/language/en-extensions.json
@@ -27,6 +27,7 @@
     },
     "BOOKING": {
       "BOOK_BIKE": "Book the most-charged bike",
+      "MINUTES_REMAINING": "minutes remaining",
       "REFRESH": "Refresh booking",
       "SWITCH": "Switch current booking to this station"
     },


### PR DESCRIPTION
This pull request addresses #14.

I contains the following changes:
- c867cbb95f2e7c143ef337b05c601b6e18888b38 Adds a **"Refresh booking"** button below the "Cancel booking" button in the rent-popup.
  It is only displayed when having the station open that the current booking belongs to.
- a9016d94ea9dcd354750163d7763768b8e9e914f Adds the option to **"Switch booking** to current station" when opening a station other than the one the current booking belongs to.
- eae4feee14b5cad80d089790ed40265f89f1ea64 Displays the **remaining number of minutes** before the booking expires.
