### PR TITLE
Displaying station note/motd in rent-popup

### DIFF
--- a/src/components/map/rent-popup.scss
+++ b/src/components/map/rent-popup.scss
@@ -25,13 +25,12 @@
     white-space: nowrap;
   }
 
-  .loading-station {
-    height: auto;
-    margin-top: 80px;
-
-    .ellipsis div {
-      background: #ddd;
-    }
+  .station-note {
+    background: #f2dede;
+    color: #a94442;
+    padding: 10px;
+    border: 1px solid #a94442;
+    border-radius: 5px;
   }
 
   .no-bikes {

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -138,7 +138,11 @@ const RentPopup: React.FC<RentPopupProps> = ({
           <h2 id="station-name" className="station-name">
             {selectedStation && selectedStation.name}
           </h2>
-
+          {selectedStation && selectedStation.note && (
+            <p className="station-note">
+              {selectedStation && selectedStation.note}
+            </p>
+          )}
           <hr />
 
           {!stationDetail ? (

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -140,7 +140,7 @@ const RentPopup: React.FC<RentPopupProps> = ({
           </h2>
           {selectedStation && selectedStation.note && (
             <p className="station-note">
-              {selectedStation && selectedStation.note}
+              {selectedStation.note}
             </p>
           )}
           <hr />


### PR DESCRIPTION
This PR resolves https://github.com/NeoLegends/velocity-pwa/issues/16. :tada: 

I wasn't sure if the `.note` class in `scss/_note.scss` was intended for this kind of text. The margins/paddings seemed a little too big so I decided to just wrote a separate class to the rent-popup stylesheet. We can change that easily with adding a separator to `.note` of course. So please also provide some feedback on this.

If you can't find a station with a note: StreetScooter (Jülicher Str.)