### PR TITLE
Prevent overwriting selected slot

### DIFF
--- a/src/components/map/rent-controls.tsx
+++ b/src/components/map/rent-controls.tsx
@@ -39,7 +39,7 @@ const RentControls: React.FC<RentControlsProps> = ({
   const [pin, setPin] = useSavedPin();
   const [pinInput, handlePinChange] = useFormField('');
 
-  const handleSliderComplete = useCallback(() => onRentBike(pin!), [pin]);
+  const handleSliderComplete = useCallback(() => onRentBike(pin!), [pin, onRentBike]);
   const handleSubmitPin = useCallback(
     (ev: React.FormEvent) => {
       ev.preventDefault();

--- a/src/components/map/rent-controls.tsx
+++ b/src/components/map/rent-controls.tsx
@@ -39,7 +39,10 @@ const RentControls: React.FC<RentControlsProps> = ({
   const [pin, setPin] = useSavedPin();
   const [pinInput, handlePinChange] = useFormField('');
 
-  const handleSliderComplete = useCallback(() => onRentBike(pin!), [pin, onRentBike]);
+  const handleSliderComplete = useCallback(() => onRentBike(pin!), [
+    pin,
+    onRentBike,
+  ]);
   const handleSubmitPin = useCallback(
     (ev: React.FormEvent) => {
       ev.preventDefault();

--- a/src/hooks/rent-popup.ts
+++ b/src/hooks/rent-popup.ts
@@ -25,6 +25,11 @@ export const useSelectedSlot = (
       setSelectedSlot(null);
       return;
     }
+    
+    // Don't overwrite existing selection
+    if (selectedSlot) {
+      return;
+    }
 
     // Autoselect the booked slot if we have a booking, otherwise select
     // the fullest bike.
@@ -41,7 +46,7 @@ export const useSelectedSlot = (
       setSelectedSlot(slotToSelect);
       return () => setSelectedSlot(null);
     }
-  }, [booking, openedStationId, stationDetail]);
+  }, [booking, openedStationId, selectedSlot, stationDetail]);
 
   return { selectedSlot, setSelectedSlot };
 };

--- a/src/hooks/rent-popup.ts
+++ b/src/hooks/rent-popup.ts
@@ -22,12 +22,6 @@ export const useSelectedSlot = (
   useEffect(() => {
     // Deselect when station is closed
     if (!openedStationId || !stationDetail) {
-      setSelectedSlot(null);
-      return;
-    }
-    
-    // Don't overwrite existing selection
-    if (selectedSlot) {
       return;
     }
 
@@ -46,7 +40,7 @@ export const useSelectedSlot = (
       setSelectedSlot(slotToSelect);
       return () => setSelectedSlot(null);
     }
-  }, [booking, openedStationId, selectedSlot, stationDetail]);
+  }, [booking, openedStationId, stationDetail]);
 
   return { selectedSlot, setSelectedSlot };
 };


### PR DESCRIPTION
This creates a bug where the user's selection is overwritten with the recommended slot during bike rental. That's not too good.