### PR TITLE
:pencil2: Change "Booking" to "Reservation" in translations

### DIFF
--- a/src/resources/language/en-extensions.json
+++ b/src/resources/language/en-extensions.json
@@ -28,10 +28,10 @@
       "ACTION": "Save"
     },
     "BOOKING": {
-      "BOOK_BIKE": "Book the most-charged bike",
+      "BOOK_BIKE": "Reserve the most-charged bike",
       "REMAINING": "remaining",
-      "REFRESH": "Refresh booking",
-      "SWITCH": "Switch current booking to this station"
+      "REFRESH": "Refresh reservation",
+      "SWITCH": "Switch current reservation to this station"
     },
     "RENT": {
       "SLIDE_FOR_BIKE_NO1": "Slide to rent bike at slot",


### PR DESCRIPTION
Adapt translations to match meaning and [german source translations](https://github.com/NeoLegends/velocity-pwa/blob/master/src/resources/language/de-extensions.json#L30-L34).

Fixes #38 