### PR TITLE
Deduplicate and Timeout Toasts

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -57,6 +57,7 @@ const AppBody: React.SFC<AppBodyProps> = ({ onChangeLanguage }) => {
         progressClassName="toast-progress"
         toastClassName="toast outline"
         transition={Slide}
+        pauseOnFocusLoss={false}
       />
 
       <MenuBar

--- a/src/components/map/rent-popup.tsx
+++ b/src/components/map/rent-popup.tsx
@@ -1,13 +1,13 @@
 import { Link } from '@reach/router';
 import classNames from 'classnames';
 import React, { useCallback, useContext, useEffect, useMemo } from 'react';
-import { toast } from 'react-toastify';
 
 import { useSelectedSlot, useStationDetail } from '../../hooks/rent-popup';
 import { useBooking } from '../../hooks/stations';
 import { InvalidStatusCodeError, Station } from '../../model';
 import { rentBike } from '../../model/stations';
 import { LanguageContext } from '../../resources/language';
+import { toast } from '../../util/toast';
 import Overlay from '../util/overlay';
 
 import RentControls from './rent-controls';

--- a/src/components/support.tsx
+++ b/src/components/support.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React, { useContext, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { useFormField } from '../hooks/form';
 import { useStations } from '../hooks/stations';
@@ -11,6 +10,7 @@ import {
   submitStationError,
 } from '../model/support';
 import { LanguageContext } from '../resources/language';
+import { toast } from '../util/toast';
 
 import './support.scss';
 

--- a/src/components/tariff.tsx
+++ b/src/components/tariff.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React, { useContext, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { useTariffs, useUserTariff } from '../hooks/tariff';
 import { Tariff, UserTariff } from '../model';
@@ -11,6 +10,7 @@ import {
 } from '../model/tariff';
 import { LanguageContext } from '../resources/language';
 import { toEuro } from '../util/to-euro';
+import { toast } from '../util/toast';
 
 import './tariff.scss';
 

--- a/src/hooks/authentication.ts
+++ b/src/hooks/authentication.ts
@@ -1,5 +1,4 @@
 import { useCallback, useContext, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import {
   isLoggedIn as checkIsLoggedIn,
@@ -7,6 +6,7 @@ import {
   logout as doLogout,
 } from '../model/authentication';
 import { LanguageContext } from '../resources/language';
+import { toast } from '../util/toast';
 
 import { useInterval } from './interval';
 

--- a/src/hooks/invoices.ts
+++ b/src/hooks/invoices.ts
@@ -1,9 +1,9 @@
 import { useContext, useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { Invoice } from '../model';
 import { getAllInvoices } from '../model/invoices';
 import { LanguageContext } from '../resources/language';
+import { toast } from '../util/toast';
 
 export const useInvoices = () => {
   const { BILL } = useContext(LanguageContext);

--- a/src/hooks/pwa.ts
+++ b/src/hooks/pwa.ts
@@ -1,9 +1,9 @@
 import { useCallback, useContext, useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { LanguageContext } from '../resources/language';
 import * as serviceWorker from '../serviceWorker';
 import { isIos } from '../util/is-ios';
+import { toast } from '../util/toast';
 
 export const useDesktopInstallation = () => {
   const [event, setEvent] = useState<BeforeInstallProptEvent | null>(null);

--- a/src/hooks/rent-popup.ts
+++ b/src/hooks/rent-popup.ts
@@ -1,9 +1,9 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { Booking, Slot, Slots, StationWithAddress } from '../model';
 import { getSingleStation, getSlotInfo } from '../model/stations';
 import { LanguageContext } from '../resources/language';
+import { toast } from '../util/toast';
 
 import { useInterval } from './interval';
 

--- a/src/hooks/stations.ts
+++ b/src/hooks/stations.ts
@@ -1,5 +1,4 @@
 import { useCallback, useContext, useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { Booking, Station } from '../model';
 import {
@@ -9,6 +8,7 @@ import {
   getCurrentBooking,
 } from '../model/stations';
 import { LanguageContext } from '../resources/language';
+import { toast } from '../util/toast';
 
 import { useInterval } from './interval';
 

--- a/src/hooks/tariff.ts
+++ b/src/hooks/tariff.ts
@@ -1,9 +1,9 @@
 import { useCallback, useContext, useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { Tariff, UserTariff } from '../model';
 import { getCurrentTariff, getTariffs } from '../model/tariff';
 import { LanguageContext, LanguageIdContext } from '../resources/language';
+import { toast } from '../util/toast';
 
 import { useInterval } from './interval';
 

--- a/src/hooks/transaction.ts
+++ b/src/hooks/transaction.ts
@@ -1,9 +1,9 @@
 import { useCallback, useContext, useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { Transaction } from '../model';
 import { getTransactions } from '../model/transaction';
 import { LanguageContext } from '../resources/language';
+import { toast } from '../util/toast';
 
 const TRANSACTIONS_PER_PAGE = 20;
 

--- a/src/util/toast.ts
+++ b/src/util/toast.ts
@@ -1,10 +1,10 @@
-import { toast as toastifyToast } from 'react-toastify';
+import { toast as toastifyToast, ToastOptions } from 'react-toastify';
 
 /**
  * Displays a toast which cannot be duplicated and
  * continues ticking, even when the window loses focus.
  */
-export const toast = (content: string, options: any = {}) => {
+export const toast = (content: string, options: ToastOptions = {}) => {
   if (!toastifyToast.isActive(content)) {
     return toastifyToast(content, { ...options, ...{ toastId: content } });
   }

--- a/src/util/toast.ts
+++ b/src/util/toast.ts
@@ -6,6 +6,6 @@ import { toast as toastifyToast, ToastOptions } from 'react-toastify';
  */
 export const toast = (content: string, options: ToastOptions = {}) => {
   if (!toastifyToast.isActive(content)) {
-    return toastifyToast(content, { ...options, ...{ toastId: content } });
+    return toastifyToast(content, { toastId: content, ...options });
   }
 };

--- a/src/util/toast.ts
+++ b/src/util/toast.ts
@@ -1,0 +1,11 @@
+import { toast as toastifyToast } from 'react-toastify';
+
+/**
+ * Displays a toast which cannot be duplicated and
+ * continues ticking, even when the window loses focus.
+ */
+export const toast = (content: string, options: any = {}) => {
+  if (!toastifyToast.isActive(content)) {
+    return toastifyToast(content, { ...options, ...{ toastId: content } });
+  }
+};


### PR DESCRIPTION
This PRs allows toasts to continue their timer when the window loses focus and prevents multiple of the same toasts from appearing.

Fixes #31, fixes #22 