### PR TITLE
:ambulance: Fix missing "refunded" translation

### DIFF
--- a/src/resources/language/en-extensions.json
+++ b/src/resources/language/en-extensions.json
@@ -40,7 +40,7 @@
   },
   "menu": {
     "MENU": "Menu",
-    "REFUNDED": "erstattet"
+    "REFUNDED": "refunded"
   },
   "sw": {
     "INSTALL_TO_DEVICE": "Install on device",


### PR DESCRIPTION
en Translation for `refunded` was `erstattet`, now `refunded`